### PR TITLE
change enforcer JavaVersion config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1053,10 +1053,10 @@
                 </requireMavenVersion>
 
                 <!--
-                Require Java 8+
+                Require Java 8+, and less than 9
                 -->
                 <requireJavaVersion>
-                  <version>[1.8,)</version>
+                  <version>[1.8,1.9)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
Changes enforcer config to flag need for java 8 to build.
Prior setting did not cause enforcer to fail the build with Java >= 9, and instead other errors occur that are not obviously due to Java version.